### PR TITLE
big PR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 *egg-info/
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 *egg-info/
 .env
+.venv

--- a/FTX/client.py
+++ b/FTX/client.py
@@ -29,16 +29,13 @@ class DoesntExist(Exception):
 
 
 class Client:
-    def __init__(self, key, secret, subaccount=None, timeout=30):
+    def __init__(self, key: str, secret: str, subaccount: Optional[str] = None, timeout: int = 30):
         self._api_key = key
         self._api_secret = secret
         self._api_subaccount = subaccount
-        self._api_timeout = int(timeout)
+        self._api_timeout = timeout
 
-    def _build_headers(self, scope, method, endpoint, query=None):
-        if query is None:
-            query = {}
-
+    def _build_headers(self, scope: str, method: str, endpoint: str, query: dict):
         endpoint = "/api/" + endpoint
 
         headers = {
@@ -79,10 +76,7 @@ class Client:
 
         return headers
 
-    def _build_url(self, scope, method, endpoint, query=None):
-        if query is None:
-            query = {}
-
+    def _build_url(self, scope: str, method: str, endpoint: str, query: dict):
         if scope.lower() == "private":
             url = f"{constants.PRIVATE_API_URL}/{endpoint}"
         else:
@@ -93,7 +87,7 @@ class Client:
         else:
             return url
 
-    def _send_request(self, method, endpoint, query=None):
+    def _send_request(self, method: str, endpoint: str, query: Optional[dict] = None):
         query = query or {}
 
         scope = "public"
@@ -225,7 +219,7 @@ class Client:
             future for future in self.get_public_all_futures() if future["perpetual"]
         ]
 
-    def get_future(self, pair):
+    def get_future(self, pair) -> dict:
         """
         https://docs.ftx.com/#get-future
 
@@ -245,7 +239,7 @@ class Client:
 
         return self._GET(f"futures/{pair.upper()}/stats")
 
-    def get_funding_rates(self):
+    def get_funding_rates(self) -> ListOfDicts:
         """
         https://docs.ftx.com/#get-funding-rates
 
@@ -755,7 +749,7 @@ class Client:
         return self._POST(f"conditional_orders", query)
 
     # TODO: Either price or size must be specified
-    def modify_order(self, orderId, price=None, size=None, clientId=None):
+    def modify_order(self, orderId: str, price: Optional[float] = None, size=None, clientId=None):
         """
         https://docs.ftx.com/#modify-order
 

--- a/FTX/client.py
+++ b/FTX/client.py
@@ -223,7 +223,7 @@ class Client:
         :return: a list contains all available perpetual futures
         """
         return [
-            future for future in self.get_public_all_futures() if future["perpetual"]
+            future for future in self.get_futures() if future["perpetual"]
         ]
 
     def get_future(self, pair: str) -> dict:

--- a/FTX/constants.py
+++ b/FTX/constants.py
@@ -17,3 +17,4 @@ PRIVATE_ENDPOINTS = (
     "funding_payments",
 )
 VALID_CHAINS = ("omni", "erc20", "trx", "sol", "bep2")
+RATE_LIMIT_PER_SECOND = 30

--- a/FTX/constants.py
+++ b/FTX/constants.py
@@ -16,3 +16,4 @@ PRIVATE_ENDPOINTS = (
     "fills",
     "funding_payments",
 )
+VALID_CHAINS = ("omni", "erc20", "trx", "sol", "bep2")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+certifi==2020.12.5
+chardet==4.0.0
+expiringdict==1.2.1
+idna==2.10
+requests==2.25.1
+urllib3==1.26.4


### PR DESCRIPTION
PEP8 for import order and line length.
Type hints everywhere.
Since `query` is only fed into `_build_url` and `_build_headers`, removed the `if query is None`, since that's dealt with in the calling code.
Validated `chain` argument of `get_deposit_address`.
Replaced all `limit` arg defaults with a configured constant.
Added requirements.txt.
Added rate limiting.

fixes #4 
fixes #6 